### PR TITLE
Re-add Pokémon CP

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -627,6 +627,7 @@ var mapView = {
         pkmnName +
         '</b><br><div class="progress pkmn-progress pkmn-' + pkmnNum + '"> <div class="determinate pkmn-' + pkmnNum + '" style="width: ' + (pkmnHP / pkmnMHP) * 100 +'%"></div> </div>'+
         '<b>HP:</b> ' + pkmnHP + ' / ' + pkmnMHP +
+        '<br><b>CP:</b>' + pkmnCP +
         '<br><b>IV:</b> ' + (pkmnIV >= 0.8 ? '<span style="color: #039be5">' + pkmnIV + '</span>' : pkmnIV) +
         '<br><b>A/D/S:</b> ' + pkmnIVA + '/' + pkmnIVD + '/' + pkmnIVS +
         '<br><b>Candy: </b>' + candyNum +


### PR DESCRIPTION
#4cee7e1 accidentally removed Pokémon CP stat listing so we add it back in.